### PR TITLE
Frontend lint 29 errors → 0, and the flaky test behind them

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -101,13 +101,13 @@ const App = () => {
                     if (userItem && userItem !== 'null' && userItem !== 'undefined' && userItem !== '') {
                         JSON.parse(userItem);
                     }
-                } catch (parseError) {
+                } catch {
                     // Silently ignore parse errors
                 }
             }
         } catch (error) {
             // Silently handle any localStorage errors - don't break the app
-            if (process.env.NODE_ENV === 'development') {
+            if (import.meta.env.DEV) {
                 console.error('Error accessing user from storage:', error);
             }
         }

--- a/frontend/src/components/AIStudyBuddyModals.jsx
+++ b/frontend/src/components/AIStudyBuddyModals.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import './AIStudyBuddyModals.css';
@@ -162,11 +162,14 @@ export const QuizCreatorModal = ({ isOpen, onClose, onSubmit, initialData = {} }
 
 // Quiz Preview Modal
 export const QuizPreviewModal = ({ isOpen, onClose, quiz, onTakeQuiz }) => {
-    if (!quiz) return null;
-
-    const previewQuestions = quiz.questions?.slice(0, 2) || [];
-
-    // Keyboard shortcuts
+    // Above the early return, because React matches hooks by call order and
+    // this component is mounted permanently by AIStudyBuddy with
+    // `quiz={modalData.quizPreview}` — null until somebody previews something.
+    // It survives today only because a render with *no* hooks is
+    // indistinguishable from a mount, so React re-mounts the hook rather than
+    // throwing. That is luck, not design: add one hook above this line and the
+    // null -> set transition becomes "Rendered more hooks than during the
+    // previous render", on the one interaction this component exists for.
     useKeyboardShortcuts({
         'Escape': () => {
             if (isOpen) {
@@ -174,6 +177,10 @@ export const QuizPreviewModal = ({ isOpen, onClose, quiz, onTakeQuiz }) => {
             }
         },
     }, [isOpen]);
+
+    if (!quiz) return null;
+
+    const previewQuestions = quiz.questions?.slice(0, 2) || [];
 
     const handleTakeQuiz = () => {
         if (onTakeQuiz) {

--- a/frontend/src/components/AdvancedThemeSelector.jsx
+++ b/frontend/src/components/AdvancedThemeSelector.jsx
@@ -362,7 +362,6 @@ const AdvancedThemeSelector = () => {
         }
 
         // Handle regular theme preview
-        const requiredLevel = themeLevels[themeName];
         const isUnlocked = themeName === "Default" || unlocked.includes(themeName);
         if (isUnlocked && themeName !== currentTheme) {
             setPreviewTheme(themeName);
@@ -862,7 +861,7 @@ const AdvancedThemeSelector = () => {
                 return;
             }
 
-            const response = await axios.post(`/api/users/${userId}/custom-theme`, {
+            await axios.post(`/api/users/${userId}/custom-theme`, {
                 name: customThemeName.trim(),
                 themeData: customTheme
             });

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -7,7 +7,7 @@ class ErrorBoundary extends React.Component {
     this.state = { hasError: false, error: null, errorInfo: null };
   }
 
-  static getDerivedStateFromError(error) {
+  static getDerivedStateFromError() {
     return { hasError: true };
   }
 
@@ -34,7 +34,7 @@ class ErrorBoundary extends React.Component {
             <p className="error-boundary-message">
               We're sorry, but something unexpected happened. Please try refreshing the page.
             </p>
-            {process.env.NODE_ENV === 'development' && this.state.error && (
+            {import.meta.env.DEV && this.state.error && (
               <details className="error-boundary-details">
                 <summary>Error Details (Development Only)</summary>
                 <pre className="error-boundary-stack">

--- a/frontend/src/components/GamificationHub.jsx
+++ b/frontend/src/components/GamificationHub.jsx
@@ -24,7 +24,7 @@ const GamificationHub = () => {
 
     // Leaderboard states
     const [showLeaderboardModal, setShowLeaderboardModal] = useState(false);
-    const [selectedTournamentId, setSelectedTournamentId] = useState(null);
+    const [, setSelectedTournamentId] = useState(null);
     const [leaderboardData, setLeaderboardData] = useState(null);
     const [loadingLeaderboard, setLoadingLeaderboard] = useState(false);
 

--- a/frontend/src/components/StudyStreakGoals.jsx
+++ b/frontend/src/components/StudyStreakGoals.jsx
@@ -115,7 +115,7 @@ const StudyStreakGoals = () => {
     }
 
     const calendarDays = generateCalendarDays();
-    const { currentStreak, longestStreak, goalsProgress, todayActivity } = streakData;
+    const { currentStreak, longestStreak, goalsProgress } = streakData;
 
     return (
         <div className="study-streak-container">

--- a/frontend/src/context/ThemeProvider.jsx
+++ b/frontend/src/context/ThemeProvider.jsx
@@ -120,7 +120,7 @@ export const ThemeProvider = ({ children }) => {
                     setTheme(storedUser.selectedTheme);
                     document.documentElement.setAttribute("data-theme", storedUser.selectedTheme);
                 }
-            } catch (_) {
+            } catch {
                 // Never let interval throw – safeParseJSON should not throw; guard anyway
             }
         }, 1000);

--- a/frontend/src/pages/AdminReports.jsx
+++ b/frontend/src/pages/AdminReports.jsx
@@ -389,21 +389,6 @@ const AdminReports = () => {
         }
     };
 
-    const tableRowVariants = {
-        hidden: { x: -50, opacity: 0 },
-        visible: {
-            x: 0,
-            opacity: 1,
-            transition: { duration: 0.4, ease: "easeOut" }
-        },
-        exit: {
-            x: 50,
-            opacity: 0,
-            scale: 0.9,
-            transition: { duration: 0.3 }
-        }
-    };
-
     if (loading) return <Loading fullScreen={true} />;
 
     return (

--- a/frontend/src/pages/Bookmarks.jsx
+++ b/frontend/src/pages/Bookmarks.jsx
@@ -8,7 +8,6 @@ import Loading from "../components/Loading";
 import { useNotification } from "../hooks/useNotification";
 import NotificationModal from "../components/NotificationModal";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
-import { debounce } from "../utils/componentUtils";
 import CustomDropdown from "../components/CustomDropdown";
 import { addToQuizHistory } from "../utils/quizHistory";
 import { markQuizFullscreenOnLoad } from "../utils/quizFullscreen.js";
@@ -22,7 +21,6 @@ const Bookmarks = () => {
     // Filter and sort states
     const [searchQuery, setSearchQuery] = useState("");
     const [categoryFilter, setCategoryFilter] = useState("all");
-    const [difficultyFilter, setDifficultyFilter] = useState("all");
     const [sortBy, setSortBy] = useState("date"); // date, title, category
     const [viewMode, setViewMode] = useState("grid"); // grid, list
     const [currentPage, setCurrentPage] = useState(1);

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -12,7 +12,7 @@ import { handlePageChangeWithScrollPreservation, restoreScrollPosition } from ".
 import "./Leaderboard.css";
 
 // Memoized Leaderboard Row Component
-const LeaderboardRow = memo(({ user, rank, index, quizName }) => {
+const LeaderboardRow = memo(({ user, rank, quizName }) => {
     const getMedal = (rank) => {
         if (rank === 1) return "🥇";
         if (rank === 2) return "🥈";
@@ -235,10 +235,11 @@ const Leaderboard = () => {
                 switch (sortBy) {
                     case "username":
                         return (a.username || '').localeCompare(b.username || '');
-                    case "percentage":
+                    case "percentage": {
                         const aPct = a.total > 0 ? (a.score / a.total) * 100 : 0;
                         const bPct = b.total > 0 ? (b.score / b.total) * 100 : 0;
                         return bPct - aPct;
+                    }
                     case "score":
                     default:
                         return b.score - a.score;

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -60,7 +60,7 @@ const Register = () => {
                     delete newErrors.email;
                 }
                 break;
-            case 'password':
+            case 'password': {
                 const strength = getPasswordStrength(value);
                 if (!value) {
                     newErrors.password = 'Password is required';
@@ -80,6 +80,7 @@ const Register = () => {
                     }
                 }
                 break;
+            }
             case 'confirmPassword':
                 if (!value) {
                     newErrors.confirmPassword = 'Please confirm your password';

--- a/frontend/src/pages/TakeQuiz.jsx
+++ b/frontend/src/pages/TakeQuiz.jsx
@@ -56,7 +56,7 @@ const TakeQuiz = () => {
     const isSubmitButtonClicked = useRef(false);
 
     // Notification system
-    const { notification, showSuccess, showError, hideNotification } = useNotification();
+    const { notification, showError, hideNotification } = useNotification();
 
     // Record answer time function
     const recordAnswerTime = useCallback(() => {
@@ -1307,8 +1307,6 @@ const TakeQuiz = () => {
                         <div className="review-content">
                             {reviewQuestions.map((q, idx) => {
                                 const isCorrect = q.userAnswer === q.correctAnswer;
-                                const userOptionIndex = optionLetters.indexOf(q.userAnswer);
-                                const correctOptionIndex = optionLetters.indexOf(q.correctAnswer);
                                 return (
                                     <div key={idx} className={`review-question-card ${isCorrect ? 'correct' : 'incorrect'}`}>
                                         <div className="review-question-header">

--- a/frontend/src/pages/ThemePage.jsx
+++ b/frontend/src/pages/ThemePage.jsx
@@ -91,7 +91,6 @@ const ThemePage = () => {
     // Preview logic
     const [previewTheme, setPreviewTheme] = useState(null);
     const handlePreview = (themeName) => {
-        const requiredLevel = themeLevels[themeName];
         const isUnlocked = themeName === "Default" || unlocked.includes(themeName);
         if (isUnlocked && themeName !== currentTheme) {
             setPreviewTheme(themeName);

--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -7,7 +7,6 @@ import "./UserProfile.css";
 import Loading from "../components/Loading";
 import { useNotification } from "../hooks/useNotification";
 import NotificationModal from "../components/NotificationModal";
-import { getUserFromStorage } from "../utils/localStorage";
 
 const UserProfile = () => {
     const navigate = useNavigate();

--- a/frontend/src/pages/UserReports.jsx
+++ b/frontend/src/pages/UserReports.jsx
@@ -394,7 +394,7 @@ const UserReports = () => {
                         }
                         return;
                     }
-                } catch (err) {
+                } catch {
                     if (isMounted) {
                         setError("Error loading user data.");
                         setLoading(false);

--- a/frontend/src/pages/XPLeaderboard.jsx
+++ b/frontend/src/pages/XPLeaderboard.jsx
@@ -5,7 +5,6 @@ import axios from "../utils/axios";
 import Loading from "../components/Loading";
 import NotificationModal from "../components/NotificationModal";
 import { useNotification } from "../hooks/useNotification";
-import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 import "./Leaderboard.css";
 
 const XPLeaderboard = () => {

--- a/frontend/src/tests/componentUtils.test.js
+++ b/frontend/src/tests/componentUtils.test.js
@@ -59,18 +59,31 @@ describe('Component Utility Functions', () => {
 
   it('should combine class names', () => {
     expect(classNames('btn', 'btn-primary')).toBe('btn btn-primary')
-    expect(classNames('btn', false && 'btn-disabled', 'btn-active')).toBe('btn btn-active')
+    expect(classNames('btn', false, 'btn-active')).toBe('btn btn-active')
     expect(classNames('btn', null, undefined, 'btn-primary')).toBe('btn btn-primary')
     expect(classNames()).toBe('')
   })
 
   it('should generate random colors', () => {
-    const color1 = getRandomColor()
-    const color2 = getRandomColor()
+    // `expect(color1).not.toBe(color2)` used to sit here, commented "very
+    // unlikely to be the same". The palette holds ten colours, so it is one in
+    // ten — measured at 2 failures in 25 runs of this file. CI holds this suite
+    // strictly and with no tolerance, so that is one in ten builds failing for
+    // a reason unrelated to anything anyone changed, which is how a strict
+    // suite gets argued back down to continue-on-error.
+    //
+    // The contract is "a colour from the palette", so that is what is asserted.
+    // Randomness is checked over enough draws to be about the distribution
+    // rather than about one coin landing twice.
+    const color = getRandomColor()
+    expect(typeof color).toBe('string')
+    expect(color).toMatch(/^#[0-9A-F]{6}$/i)
 
-    expect(typeof color1).toBe('string')
-    expect(color1).toMatch(/^#[0-9A-F]{6}$/i)
-    expect(color1).not.toBe(color2) // Very unlikely to be the same
+    const seen = new Set(Array.from({ length: 200 }, () => getRandomColor()))
+    seen.forEach((c) => expect(c).toMatch(/^#[0-9A-F]{6}$/i))
+    // 200 draws from ten colours miss one with probability 10 * 0.9^200,
+    // which is about 1 in 10^8 — a rate a build can live with.
+    expect(seen.size).toBeGreaterThan(1)
   })
 
   it('should format BEM class names', () => {

--- a/frontend/src/tests/quizPreviewModal.test.jsx
+++ b/frontend/src/tests/quizPreviewModal.test.jsx
@@ -1,0 +1,58 @@
+/**
+ * QuizPreviewModal is rendered unconditionally by AIStudyBuddy, with
+ * `quiz={modalData.quizPreview}` — which starts as `null` and becomes an object
+ * when somebody previews a quiz. So the null -> set transition happens on the
+ * same mounted instance, which is the one case where a hook below an early
+ * return stops being a style question and becomes a crash.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { QuizPreviewModal } from '../components/AIStudyBuddyModals';
+
+const QUIZ = {
+  id: 'q1',
+  title: 'Photosynthesis',
+  questions: [
+    { question: 'What does chlorophyll absorb?', options: ['Light', 'Water'], correctAnswer: 0 },
+    { question: 'Where does it happen?', options: ['Chloroplast', 'Nucleus'], correctAnswer: 0 },
+  ],
+};
+
+const noop = () => {};
+
+describe('QuizPreviewModal', () => {
+  it('renders nothing when there is no quiz to preview', () => {
+    const { container } = render(
+      <QuizPreviewModal isOpen={false} onClose={noop} quiz={null} onTakeQuiz={noop} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('survives the quiz arriving on an already-mounted instance', () => {
+    // React matches hooks by call order. With the hook below `if (!quiz) return
+    // null`, the first render registers none and the second registers one, and
+    // React throws "Rendered more hooks than during the previous render" —
+    // taking the tree down on the one interaction this component exists for.
+    const { rerender } = render(
+      <QuizPreviewModal isOpen={false} onClose={noop} quiz={null} onTakeQuiz={noop} />,
+    );
+    expect(() =>
+      rerender(
+        <QuizPreviewModal isOpen onClose={noop} quiz={QUIZ} onTakeQuiz={noop} />,
+      ),
+    ).not.toThrow();
+    expect(screen.getByText('Photosynthesis')).toBeInTheDocument();
+  });
+
+  it('survives the quiz being cleared again', () => {
+    // The closing half of the same transition, which unregisters the hook.
+    const { rerender } = render(
+      <QuizPreviewModal isOpen onClose={noop} quiz={QUIZ} onTakeQuiz={noop} />,
+    );
+    expect(() =>
+      rerender(
+        <QuizPreviewModal isOpen={false} onClose={noop} quiz={null} onTakeQuiz={noop} />,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/frontend/src/utils/localStorage.js
+++ b/frontend/src/utils/localStorage.js
@@ -35,13 +35,13 @@ export const safeParseJSON = (key, defaultValue = null) => {
         try {
             return JSON.parse(item);
         } catch (parseErr) {
-            if (process.env.NODE_ENV === 'development') {
+            if (import.meta.env.DEV) {
                 console.warn(`safeParseJSON: invalid JSON for key "${key}"`, parseErr.message);
             }
             return defaultValue;
         }
     } catch (error) {
-        if (process.env.NODE_ENV === 'development') {
+        if (import.meta.env.DEV) {
             console.error(`Error parsing JSON for key "${key}":`, error);
         }
         return defaultValue;

--- a/scripts/lint-baseline.json
+++ b/scripts/lint-baseline.json
@@ -2,12 +2,18 @@
   "_comment": [
     "Recorded lint debt, so the number can only go down.",
     "Backend went 334 -> 1: 309 were auto-fixable (277 quotes, 32 semicolons) and",
-    "the rest were unused variables removed by hand. The one remaining is an",
-    "unused mock in studyGroupController.test.js, which goes when that suite is",
-    "repaired.",
-    "Frontend is untouched: none of its findings are auto-fixable, and the 29",
-    "react-hooks/exhaustive-deps ones need judgement -- adding a dependency can",
-    "turn a working effect into an infinite loop.",
+    "the rest were unused variables removed by hand. It is at 0 now.",
+    "Frontend errors went 29 -> 0. The note that used to sit here said its 29",
+    "findings were the react-hooks/exhaustive-deps ones needing judgement. That",
+    "described the 29 WARNINGS. The 29 ERRORS were a different list entirely:",
+    "20 unused variables, 4 uses of `process.env.NODE_ENV` in a Vite app, 3",
+    "lexical declarations in switch cases, one hook called below an early",
+    "return, and one test assertion that was constant-true. Reading the count",
+    "instead of the findings is how the interesting ones stayed hidden behind a",
+    "number that looked like formatting debt.",
+    "The 29 warnings are genuinely exhaustive-deps and are genuinely judgement:",
+    "adding a dependency can turn a working effect into an infinite loop. They",
+    "stay until each one is read on its own.",
     "Fix some, then lower these. The ratchet fails if they grow, and also if they",
     "shrink without this file being updated."
   ],
@@ -16,7 +22,7 @@
     "warnings": 0
   },
   "frontend": {
-    "errors": 29,
+    "errors": 0,
     "warnings": 29
   }
 }


### PR DESCRIPTION
`scripts/lint-baseline.json` said:

> Frontend is untouched: none of its findings are auto-fixable, and **the 29
> react-hooks/exhaustive-deps ones need judgement**

That describes the 29 **warnings**. The 29 **errors** were a different list
entirely, and reading the count instead of the findings is how the interesting
ones stayed hidden behind a number that looked like formatting debt:

```
 20  no-unused-vars
  4  no-undef                      (process, in a Vite app)
  3  no-case-declarations
  1  react-hooks/rules-of-hooks
  1  no-constant-binary-expression
```

## The one that mattered: a test that fails 1 run in 10

```js
expect(color1).not.toBe(color2) // Very unlikely to be the same
```

`getRandomColor()` picks from a palette of **ten**. So it is not unlikely, it is
one in ten — and CI holds this suite strictly:

> The frontend suite passes 52/52, so it is held strictly. **No tolerance here.**

Measured, not assumed:

```
collision rate over 200000 trials: 9.97%
real suite: 2 of 25 runs failed
```

**One build in ten failing for a reason unrelated to anything anyone changed.**
That is exactly how a strict suite gets argued back down to
`continue-on-error` — which this repo has only just finished undoing, across
several commits.

It now asserts the contract — a colour from the palette — and checks the spread
over 200 draws rather than betting on two. After: **0 of 25 runs failed**.

## The hook below an early return

`QuizPreviewModal` called `useKeyboardShortcuts` after `if (!quiz) return null`,
and `AIStudyBuddy` mounts it permanently with `quiz={modalData.quizPreview}` —
which starts `null`.

I expected a crash and wrote a test to prove it. **It passed.** React picks the
mount dispatcher when the previous render stored no hook state, so a render with
*zero* hooks is indistinguishable from a mount and the hook simply re-mounts.

So this is luck, not correctness: add one hook above that line and the
`null → set` transition becomes *"Rendered more hooks than during the previous
render"*, on the one interaction the component exists for. The hook moved above
the early return, with a test covering both directions of the transition.

## `process.env.NODE_ENV` in a Vite app

Four of them, all inside error handlers. They work today only because esbuild
statically replaces that one expression during the build — nothing defines
`process`, and `vite.config.js`'s `define` block does not mention it. The guard
depends on an implicit default rather than on anything this repo declares.
`import.meta.env.DEV` is the idiom Vite actually offers.

(I checked the bundle before claiming a runtime error: `process.env.NODE_ENV`
does *not* survive into `dist`, so this is fragility, not a live crash.)

## The rest

3 lexical declarations in `switch` cases, now in their own blocks. 20 unused
variables: dead locals, unused imports, catch bindings never read, and two
indices in the quiz review screen that the inner `map` recomputes from `letter`
anyway.

## Verification, the way CI runs it

```
frontend: 0 errors (baseline 0), 29 warnings (baseline 29)   ok
backend:  0 errors (baseline 0), 0 warnings (baseline 0)     ok
suites: 0 failing (baseline 0)
tests : 0 failing (baseline 0), 174 passing of 174           ok
frontend suite: 55 passed (was 52 — 3 new)
vite build: clean
```

Plus 25 consecutive runs of the repaired test file, 0 failures.

## Left alone deliberately

The 29 `exhaustive-deps` **warnings**. Those genuinely are judgement — adding a
dependency can turn a working effect into an infinite loop — and each needs
reading on its own. The baseline comment now says which 29 are which, so the
next person does not have to re-derive it.